### PR TITLE
Replace Intl.NumberFormat with numerals.js

### DIFF
--- a/src/content/Dashboards/GatewayPools/DepositOverTime.tsx
+++ b/src/content/Dashboards/GatewayPools/DepositOverTime.tsx
@@ -2,6 +2,7 @@ import { Card, Box, useTheme, CardHeader, Divider, CardContent, Skeleton } from 
 
 import { Chart } from 'src/components/Chart';
 import type { ApexOptions } from 'apexcharts';
+import { amountFormatter } from '@/utils/numberFormatters';
 
 function DepositOverTime({ data, loading }) {
   const theme = useTheme();
@@ -39,9 +40,8 @@ function DepositOverTime({ data, loading }) {
         }
       },
     },
-    colors: [theme.colors.primary.main],
     dataLabels: {
-      enabled: false
+      enabled: false,
     },
     fill: {
       opacity: 1
@@ -112,12 +112,7 @@ function DepositOverTime({ data, loading }) {
         style: {
           colors: theme.palette.text.secondary
         },
-        formatter: value => new Intl.NumberFormat('default', {
-          notation: "compact",
-          compactDisplay: "short",
-          minimumFractionDigits: 0,
-          maximumFractionDigits: 2
-        }).format(value)
+        formatter: value => amountFormatter(value)
       },
       title: {
         text: 'UST amount',

--- a/src/content/Dashboards/Metrics/MetricsTable.tsx
+++ b/src/content/Dashboards/Metrics/MetricsTable.tsx
@@ -12,6 +12,7 @@ import {
   TableContainer,
   CardHeader, Skeleton
 } from '@mui/material';
+import { amountFormatter } from '@/utils/numberFormatters';
 
 const PercentileLabels = {
   percentile99: '99%',
@@ -68,12 +69,7 @@ function MetricsTable({ data, loading }) {
                     <TableCell>
                       <Box>
                         <Typography variant="h4">
-                          {new Intl.NumberFormat('en-US', {
-                            notation: "compact",
-                            compactDisplay: "short",
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          }).format(data[key].percentileFloor)}
+                          {amountFormatter(data[key].percentileFloor)}
                         </Typography>
                       </Box>
                     </TableCell>
@@ -85,12 +81,7 @@ function MetricsTable({ data, loading }) {
                     <TableCell align="right">
                       <Box>
                         <Typography variant="h4">
-                          {new Intl.NumberFormat('en-US', {
-                            notation: "compact",
-                            compactDisplay: "short",
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          }).format(data[key].amountOfMine)}
+                          {amountFormatter(data[key].amountOfMine)}
                         </Typography>
                       </Box>
                     </TableCell>

--- a/src/content/Dashboards/Staking/ContinuousDaysWalletsStaked.tsx
+++ b/src/content/Dashboards/Staking/ContinuousDaysWalletsStaked.tsx
@@ -9,6 +9,7 @@ import {
 
 import { Chart } from 'src/components/Chart';
 import type { ApexOptions } from 'apexcharts';
+import { amountFormatter } from '@/utils/numberFormatters';
 
 function TotalMineStakedCumulative({ data, loading }) {
   const theme = useTheme();
@@ -93,12 +94,7 @@ function TotalMineStakedCumulative({ data, loading }) {
         style: {
           colors: theme.palette.text.secondary
         },
-        formatter: value => new Intl.NumberFormat('default', {
-          notation: "compact",
-          compactDisplay: "short",
-          minimumFractionDigits: 0,
-          maximumFractionDigits: 2
-        }).format(value)
+        formatter: value => amountFormatter(value)
       },
       title: {
         text: 'record count',

--- a/src/content/Dashboards/Staking/NewStakersPerDay.tsx
+++ b/src/content/Dashboards/Staking/NewStakersPerDay.tsx
@@ -9,6 +9,7 @@ import {
 
 import { Chart } from 'src/components/Chart';
 import type { ApexOptions } from 'apexcharts';
+import { amountFormatter } from '@/utils/numberFormatters';
 
 function NewStakersPerDay({ data, loading }) {
   const theme = useTheme();
@@ -99,12 +100,7 @@ function NewStakersPerDay({ data, loading }) {
         style: {
           colors: theme.palette.text.secondary
         },
-        formatter: value => new Intl.NumberFormat('default', {
-          notation: "compact",
-          compactDisplay: "short",
-          minimumFractionDigits: 0,
-          maximumFractionDigits: 2
-        }).format(value)
+        formatter: value => amountFormatter(value)
       },
       title: {
         text: 'new stakers',

--- a/src/content/Dashboards/Staking/TotalMineStakedCumulative.tsx
+++ b/src/content/Dashboards/Staking/TotalMineStakedCumulative.tsx
@@ -9,6 +9,7 @@ import {
 
 import { Chart } from 'src/components/Chart';
 import type { ApexOptions } from 'apexcharts';
+import { amountFormatter } from '@/utils/numberFormatters';
 
 function TotalMineStakedCumulative({ data, loading }) {
   const theme = useTheme();
@@ -99,12 +100,7 @@ function TotalMineStakedCumulative({ data, loading }) {
         style: {
           colors: theme.palette.text.secondary
         },
-        formatter: value => new Intl.NumberFormat('default', {
-          notation: "compact",
-          compactDisplay: "short",
-          minimumFractionDigits: 0,
-          maximumFractionDigits: 2
-        }).format(value)
+        formatter: value => amountFormatter(value)
       },
       title: {
         text: 'MINE amount',

--- a/src/content/Dashboards/Staking/TotalMineStakedPerDay.tsx
+++ b/src/content/Dashboards/Staking/TotalMineStakedPerDay.tsx
@@ -9,6 +9,7 @@ import {
 
 import { Chart } from 'src/components/Chart';
 import type { ApexOptions } from 'apexcharts';
+import { amountFormatter } from '@/utils/numberFormatters';
 
 function TotalMineStakedPerDay({ data, loading }) {
   const theme = useTheme();
@@ -99,12 +100,7 @@ function TotalMineStakedPerDay({ data, loading }) {
         style: {
           colors: theme.palette.text.secondary
         },
-        formatter: value => new Intl.NumberFormat('default', {
-          notation: "compact",
-          compactDisplay: "short",
-          minimumFractionDigits: 0,
-          maximumFractionDigits: 2
-        }).format(value)
+        formatter: value => amountFormatter(value)
       },
       title: {
         text: 'MINE amount',

--- a/src/utils/numberFormatters.ts
+++ b/src/utils/numberFormatters.ts
@@ -1,11 +1,7 @@
-export const amountFormatter = (value: number) =>
-  new Intl.NumberFormat('default', {
-    notation: "compact",
-    compactDisplay: "short",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
+import numeral from 'numeral';
 
-  }).format(value)
+export const amountFormatter = (value: number) =>
+  numeral(value).format('0a.[00]').toUpperCase()
 
 export const percentileFormatter = (value: number) =>
   new Intl.NumberFormat('default', {


### PR DESCRIPTION
Desktop Safari  did not respect the `Intl.NumberFormat` `notation: compact` for adding the amount abbreviations.

We had to switch to using `numerals.js` for consistency.