### PR TITLE
Applies middle string truncation to wallets and txs

### DIFF
--- a/src/content/Dashboards/BuyBackDistribution/WalletDistribution.tsx
+++ b/src/content/Dashboards/BuyBackDistribution/WalletDistribution.tsx
@@ -18,6 +18,7 @@ import ClearTwoToneIcon from '@mui/icons-material/ClearTwoTone';
 import Text from '@/components/Text';
 import Link from '@/components/Link';
 import Error from '@/components/Error';
+import { stringMiddleTruncate } from '@/utils/stringMiddleTruncate';
 
 const SearchInputWrapper = styled(TextField)(
   ({ theme }) => `
@@ -223,7 +224,7 @@ function WalletDistribution() {
                   {tableData.map(({ ustAmount, mineAmount, transactionHash, createdAt }) => (
                     <TableRow key={transactionHash}>
                       <TableCell>
-                        <Box sx={{ width: '120px' }}>
+                        <Box>
                           <Link
                             href={`https://finder.extraterrestrial.money/mainnet/tx/${transactionHash}`}
                             target="_blank"
@@ -237,13 +238,12 @@ function WalletDistribution() {
                             overflow="hidden"
                             display="block"
                             sx={{
-                              width: '120px',
                               '&:hover': {
                                 textDecoration: 'underline'
                               }
                             }}
                           >
-                            {transactionHash}
+                            {stringMiddleTruncate(transactionHash)}
                           </Link>
                         </Box>
                       </TableCell>

--- a/src/content/Dashboards/GatewayPools/MineStakingStatsTable.tsx
+++ b/src/content/Dashboards/GatewayPools/MineStakingStatsTable.tsx
@@ -22,6 +22,7 @@ import Link from 'src/components/Link';
 
 import { gql, useQuery } from '@apollo/client';
 import Error from '@/components/Error';
+import { stringMiddleTruncate } from '@/utils/stringMiddleTruncate';
 
 const TableHeadWrapper = styled(TableHead)(
   ({ theme }) => `
@@ -155,19 +156,14 @@ function MineStakingStatsTable({ gatewayIdentifier }) {
                                 title={depositor}
                                 color={`${theme.colors.primary.main}`}
                                 underline="none"
-                                textOverflow="ellipsis"
                                 variant="h5"
-                                noWrap
-                                overflow="hidden"
-                                display="block"
                                 sx={{
-                                  width: '120px',
                                   '&:hover': {
                                     textDecoration: 'underline'
                                   }
                                 }}
                               >
-                                {depositor}
+                                {stringMiddleTruncate(depositor)}
                               </Link>
                             </Box>
                           </TableCell>

--- a/src/content/Dashboards/GatewayPools/WalletShares.tsx
+++ b/src/content/Dashboards/GatewayPools/WalletShares.tsx
@@ -16,6 +16,7 @@ import type { ApexOptions } from 'apexcharts';
 import { percentileFormatter } from '@/utils/numberFormatters';
 import { stringMiddleTruncate } from '@/utils/stringMiddleTruncate';
 import Error from '@/components/Error';
+import Link from '@/components/Link';
 
 
 const DotLegend = styled('span')(
@@ -161,24 +162,18 @@ function WalletShares({ data, loading, error }) {
               sm={6}
               item
               display="flex"
-              justifyContent="center"
               alignItems="center"
             >
-              <Box sx={{ width: '100%' }}>
+              <Box>
                 {loading
                   ? Array.from(Array(9), Math.random).map((value) => (
-                      <Skeleton key={value} sx={{ py: 0.8, fontSize: 10 }} />
+                      <Skeleton key={value} sx={{ py: 0.8, fontSize: 10, width: '20em' }} />
                     ))
                   : data.map(({ wallet }, i: number) => (
                       <Typography
                         key={wallet}
                         variant="body2"
-                        noWrap
-                        sx={{
-                          textOverflow: 'ellipsis',
-                          overflow: 'hidden',
-                          py: 0.6
-                        }}
+                        sx={{ py: 0.6 }}
                       >
                         <DotLegend
                           style={{
@@ -194,7 +189,22 @@ function WalletShares({ data, loading, error }) {
                         >
                           {percentileFormatter(data[i].inPercent / 100)}
                         </span>
-                        {wallet}
+                        <Link
+                          href={`https://finder.extraterrestrial.money/mainnet/address/${wallet}`}
+                          target="_blank"
+                          rel="noopener"
+                          title={wallet}
+                          color={`${theme.colors.primary.main}`}
+                          underline="none"
+                          variant="h5"
+                          sx={{
+                            '&:hover': {
+                              textDecoration: 'underline'
+                            }
+                          }}
+                        >
+                          {stringMiddleTruncate(wallet)}
+                        </Link>
                       </Typography>
                     ))}
               </Box>

--- a/src/content/Dashboards/WalletAmounts/WalletAmountsTable.tsx
+++ b/src/content/Dashboards/WalletAmounts/WalletAmountsTable.tsx
@@ -20,6 +20,7 @@ import Link from 'src/components/Link';
 
 import { gql, useQuery } from '@apollo/client';
 import Error from '@/components/Error';
+import { stringMiddleTruncate } from '@/utils/stringMiddleTruncate';
 
 const TableHeadWrapper = styled(TableHead)(
   ({ theme }) => `
@@ -150,19 +151,14 @@ function WalletAmountsTable() {
                               title={wallet}
                               color={`${theme.colors.primary.main}`}
                               underline="none"
-                              textOverflow="ellipsis"
                               variant="h5"
-                              noWrap
-                              overflow="hidden"
-                              display="block"
                               sx={{
-                                width: '120px',
                                 '&:hover': {
                                   textDecoration: 'underline'
                                 }
                               }}
                             >
-                              {wallet}
+                              {stringMiddleTruncate(wallet)}
                             </Link>
                           </Box>
                         </TableCell>

--- a/src/utils/stringMiddleTruncate.ts
+++ b/src/utils/stringMiddleTruncate.ts
@@ -1,4 +1,8 @@
-export const stringMiddleTruncate = (fullStr: string, strLen: number, separator = '...') => {
+export const stringMiddleTruncate = (
+  fullStr: string,
+  strLen: number = 20,
+  separator = '...'
+) => {
   if (fullStr.length <= strLen) return fullStr;
 
   const sepLen = separator.length,


### PR DESCRIPTION
This PR:

Applies `stringMiddleTruncate` to all instances of  wallet and transaction addresses.
This function will truncate a string by keeping the first and last 10 chars, separated with `...`

Makes wallets in pie chart component links.

![image](https://user-images.githubusercontent.com/13333997/150842998-d9f00dcc-9d05-4b3c-a5f5-0bea1289e747.png)
