### PR TITLE
fix: sort gw pools by "closest to be" claimable

### DIFF
--- a/src/content/Dashboards/MyGatewayPools/MyGatewayPoolsList.tsx
+++ b/src/content/Dashboards/MyGatewayPools/MyGatewayPoolsList.tsx
@@ -80,7 +80,7 @@ function MyGatewayPoolsList({ sortBy }) {
         );
       } else if (sortBy === GatewayPoolsSortBy['CLAIM_AT']) {
         setMyGatewayPools(
-          [...data.myGatewayPools].sort((a, b) => sortByDate(a, b, 'claimAt'))
+          [...data.myGatewayPools].sort((a, b) => sortByDate(a, b, 'claimAt')).reverse()
         );
       }
     }


### PR DESCRIPTION
Basically reverse the current sorting implemented, so that those that a "nearest" to be claimable will appear at the top of the list.